### PR TITLE
Fix maximum recursion depth exceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The command line options have the following meanings:
    * `packages`: Add any number of positional arguments, specifying full paths to nix store objects.  This packages will be graphed.
    * `--configfile`, or `-c`:  A configuration file in .ini format
    * `--configsection`, or `-s`: If the configuration file contains more than one section, you must specify this option
-   * `--output`, or `-o`: The name of the png file to output (defaults to nix-tree.png)
+   * `--output`, or `-o`: The name of the output file (defaults to frame.png). Output filename extension determines the output format. Common supported formats include: png, jpg, pdf, and svg. For a full list of supported formats, see [matplotlib.pyplot.savefig](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html). In addition to [matplotlib.pyplot.savefig](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html) supported output formats, the tool supports output in csv format to allow post-processing the output data. Specify output file with .csv extension to output the result in textual csv format.
    * `--verbose`: If this flag is present then print extra information to stdout.
 
 ## Configuration Files

--- a/default.nix
+++ b/default.nix
@@ -5,11 +5,12 @@
 
 pythonPackages.buildPythonPackage rec {
   name = "nix-visualize-${version}";
-  version = "1.0.4";
+  version = "1.0.5";
   src = ./.;
   propagatedBuildInputs = with pythonPackages; [
     matplotlib
     networkx
     pygraphviz
+    pandas
   ];
 }

--- a/nix_visualize/graph_objects.py
+++ b/nix_visualize/graph_objects.py
@@ -9,8 +9,8 @@ class Edge(object):
     def __init__(self, node_from, node_to):
         self.nfrom_raw=node_from
         self.nto_raw=node_to
-        self.nfrom = util.remove_nix_hash(os.path.basename(self.nfrom_raw))
-        self.nto = util.remove_nix_hash(os.path.basename(self.nto_raw))
+        self.nfrom = os.path.basename(self.nfrom_raw)
+        self.nto = os.path.basename(self.nto_raw)
 
     def __repr__(self):
         return "{} -> {}".format(self.nfrom, self.nto)
@@ -21,7 +21,6 @@ class Node(object):
 
     def __init__(self, name):
         self.raw_name = name
-        self.name = util.remove_nix_hash(self.raw_name)
         self.children = []
         self.parents = []
         self.in_degree = 0
@@ -56,14 +55,21 @@ class Node(object):
             return 0
 
     def __repr__(self):
-            return self.name
+        return util.remove_nix_hash(self.raw_name)
 
     def __hash__(self):
         """A package is uniquely identified by its name"""
-        return hash((self.name,))
+        return hash((self.raw_name,))
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            return self.name == other.name
+            return self.raw_name == other.raw_name
         else:
             return False
+
+    def to_dict(self):
+        """Return Node as dictionary"""
+        return {
+            'raw_name': self.raw_name,
+            'level': self.level,
+        }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 import sys
 
 PACKAGE_NAME = "nix_visualize"
-VERSION = "1.0.4"
+VERSION = "1.0.5"
 setuptools.setup(
     name=PACKAGE_NAME,
     version=VERSION,
@@ -18,7 +18,8 @@ setuptools.setup(
     install_requires=[
         "matplotlib>=1.5",
         "networkx>=1.11",
-        "pygraphviz>=1.3"
+        "pygraphviz>=1.3",
+        "pandas>=1.5"
     ],
     data_files = [],
     entry_points={"console_scripts": [


### PR DESCRIPTION
- Fix the "maximum recursion depth exceeded" error by operating on the store object 'raw_name' instead of the store object names with hashes removed. For more details, see: https://github.com/craigmbooth/nix-visualize/issues/4.

- Support output in CSV format to allow post-processing the results with other tools. CSV output simply exports node properties "raw_name" and "level".

- Document the '--output' argument usage to allow result export in other formats also (e.g. svg, pdf, jpg).

- Bump the version to 1.0.5.